### PR TITLE
Deleter status monitoring on website

### DIFF
--- a/components/emo/js/daqcontrol.js
+++ b/components/emo/js/daqcontrol.js
@@ -794,7 +794,7 @@ function GetHealth(pctarray, static_dir, update_time, deleter_time){
     var dtimediff = 0;
     if(! isNaN( deleter_time.getTime()) )
 	dtimediff = Math.abs(now.getTime() - deleter_time.getTime())/1000.;
-    if(isNaN( update_time.getTime() ) || timeDiff > 300){
+    if(isNaN( deleter_time.getTime() ) || dtimediff > 300){
         health = "<strong style='color:red'>Data deleter inactive</strong>";
         image="<img src='"+static_dir+"/doom_faces/clean_pissed.png' style='width:50px' class='center-block'>";
     }


### PR DESCRIPTION
Hi Dan, Veronica reported seeing 'data deleted inactive' on the website a few times last week.  Looking at the website code it seems this gets activated whenever the eventbuilder is more than 5 minutes behind (or the time field is missing) regardless of the deleter status. This might fix it; sorry for misunderstanding the code otherwise. 